### PR TITLE
Fix some stuff in `boolean_expressions_java.md`

### DIFF
--- a/boolean_expressions_java.md
+++ b/boolean_expressions_java.md
@@ -88,8 +88,8 @@ For this section, we will assume that `a` and `b` are `boolean` values (`true` o
 | a | b | a &#124;&#124; b |
 |---|---|------|
 |false|false|false|
-|false|true|false|
-|true|false|false|
+|false|true|true|
+|true|false|true|
 |true|true|true|
 
 <!--<table>

--- a/boolean_expressions_java.md
+++ b/boolean_expressions_java.md
@@ -68,7 +68,7 @@ The following are the six relational operators we will use:
 
 For this section, we will assume that `a` and `b` are `boolean` values (`true` or `false`)
 
-## && (and) operator
+## `&&` (and) operator
 
 `a && b` is `true` when **both** boolean operands, `a` and `b`, are `true`
 
@@ -80,7 +80,7 @@ For this section, we will assume that `a` and `b` are `boolean` values (`true` o
 |true|true|true|
 
 
-## || (or) operator
+## `||` (or) operator
 `a || b` is `true` when **either** of the boolean operands, `a` **or** `b`, is `true`.
 
 <!-- &#124; is pipe -->
@@ -120,7 +120,7 @@ For this section, we will assume that `a` and `b` are `boolean` values (`true` o
     </tr>
 </table>-->
 
-## ! (not) operator
+## `!` (not) operator
 
 The `!` (not) operator negates the boolean value to which it is applied.
 
@@ -141,7 +141,7 @@ Order of operations is,
 
 # Short-circuit logic
 
-## Short-circuiting &&
+## Short-circuiting `&&`
 
 If the first of the two boolean values is `false`, Processing or java doesn't bother evaluating the second boolean value.
 
@@ -167,7 +167,7 @@ false && a<=20
 But, both `false && false` and `false && true` are `false`.
 So, no need to evaluate the second sub-expression.
 
-## Short-circuiting ||
+## Short-circuiting `||`
 
 If the first of the two sub-expressions (`a`) is `true`, `a || b` becomes true.
 
@@ -226,8 +226,8 @@ Examples:
 1. `20 == 4 && 12*31 >= 41*9 && 1973%127 > 50 && 1000==1000`
 1. `2+8 == 10 || 1729*9271 != 16029559 || 1000==2000`
 
-
-# Solutions
+<details>
+    <summary>Solutions</summary>
 
 1. `6 > 4` = `true`
 1. `6 > 4 == true` = `true` 
@@ -251,4 +251,4 @@ Examples:
 1. `!(1 == 7 && 2 == 9) && !(true && !false)` = `false`
 1. `20 == 4 && 12*31 >= 41*9 && 1973%127 > 50 && 1000==1000` = `false` (short-circuit `&&`)
 1. `2+8 == 10 || 1729*9271 != 16029559 || 1000==2000` = `true` (short circuit `||`)
-
+</details>

--- a/classes_array_of_objects.md
+++ b/classes_array_of_objects.md
@@ -71,27 +71,27 @@ null
 null
 ```
 
-Each item of the array is a `Rectangle` reference, and initialized to the default value (which, for objects, is `null`).
+Each item of the array is a `Rectangle` reference, and initialised to the default value (which, for objects, is `null`).
 
 The memory diagram for the current state of the array is
 
 ![](./fig/03-classes-and-objects/array-of-objects-figure0.png)
 
-Any attempt to access an instance variable or instance method on any of the items of the array will raise a `NullPointerException`.
+Any attempt to access an instance variable or instance method on any of the items of the array will throw a `NullPointerException`.
 
 ```java
-blocks[0].width = 5; //NullPointerException
-String str = blocks[0].toString(); //NullPointerException
+blocks[0].width = 5; // NullPointerException
+String str = blocks[0].toString(); // NullPointerException
 ```
 
-## Hence...
+### Hence...
 
 #### STEP 2 - Instantiating each object
 
 ```java
 for(int i=0; i < blocks.length; i++) {
-	blocks[i] = new Rectangle(i+1, i*2); //instantiate item at index i
-	System.out.println(blocks[i]); //display it
+	blocks[i] = new Rectangle(i+1, i*2); // instantiate item at index i
+	System.out.println(blocks[i]); // display it
 }
 ```
 
@@ -173,8 +173,8 @@ for(int i=0; i < data.length; i++) {
 You can also access an instance variable or instance method on any of the items of the array.
 
 ```java
-blocks[0].width = 5; //change the width of the first item to 5
-int h = blocks[3].height; //store height of fourth item into h
+blocks[0].width = 5; // change the width of the first item to 5
+int h = blocks[3].height; // store height of fourth item into h
 ```
 
-Complete code is provided in [ArrayOfObjects.java](./codes/ArrayOfObjects.java)
+The complete code for `Rectangle` and `ArrayOfObjects` is provided in [`ArrayOfObjects.java`](./codes/ArrayOfObjects.java).


### PR DESCRIPTION
wrapping solutions in a `<details>` tag to prevent early or unintentional viewing of solutions
codifying the operators in the headers and elsewhere
fix the `||` table